### PR TITLE
Patch C examples for --disable-c11-generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ ./autogen.sh
 # If you are building from a bootstrapped tarball, you can skip the
 # above autogen.sh step proceed directly to the next steps.
 
-# Run the configure script:
+# Run the configure script
 $ ./configure
 
 # Build Froozle
@@ -83,6 +83,16 @@ $ make -j 8
 # Optionally install Froozle
 $ make install
 ```
+
+# Optional features
+
+`configure` takes the following options:
+
+* `--disable-c11-generic`: This option will disable the `MPI_Count`
+  versions of the C bindings.  Specifically: `MPI_Count` will still be
+  whatever size it will be per (chapter 2 of MPI-3.1), but the C
+  bindings for `MPI_SEND` et al. will only have `int` count-enabled
+  variants, not `MPI_Count`-enabled variants.
 
 # Examples
 

--- a/examples/example_c.c
+++ b/examples/example_c.c
@@ -33,6 +33,7 @@ static void do_sends(void)
     short smallI = 16;
     MPI_Send(buffer, smallI, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 
+#if FROOZLE_HAVE_C11_GENERIC
     printf(">> The following functions should call MPI_Send_count\n");
     MPI_Count bigI = 8589934592;
     MPI_Send(buffer, bigI, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
@@ -41,6 +42,7 @@ static void do_sends(void)
     // have no C11 _Generic support.
     MPI_Send(buffer, 8589934592, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
     MPI_Send(buffer, (MPI_Count) 32, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+#endif
 }
 
 static void do_recvs(void)
@@ -55,17 +57,17 @@ static void do_recvs(void)
     MPI_Recv(buffer, smallI, MPI_CHAR, 0, 0, MPI_COMM_WORLD,
              MPI_STATUS_IGNORE);
 
+#if FROOZLE_HAVE_C11_GENERIC
     printf(">> The following functions should call MPI_Recv_count\n");
     MPI_Count bigI = 8589934592;
     MPI_Recv(buffer, bigI, MPI_CHAR, 0, 0, MPI_COMM_WORLD,
              MPI_STATUS_IGNORE);
 
-    // This one will generate a compiler warning (or error!) if you
-    // have no C11 _Generic support.
     MPI_Recv(buffer, 8589934592, MPI_CHAR, 0, 0, MPI_COMM_WORLD,
              MPI_STATUS_IGNORE);
     MPI_Recv(buffer, (MPI_Count) 32, MPI_CHAR, 0, 0, MPI_COMM_WORLD,
              MPI_STATUS_IGNORE);
+#endif
 }
 
 static void do_allgathers(void)
@@ -82,6 +84,7 @@ static void do_allgathers(void)
     MPI_Allgather(buffer, smallI, MPI_CHAR,
                   buffer, smallI, MPI_CHAR, MPI_COMM_WORLD);
 
+#if FROOZLE_HAVE_C11_GENERIC
     printf(">> The following functions should call MPI_Allgather_count\n");
     MPI_Count bigI = 8589934592;
     MPI_Allgather(buffer, bigI, MPI_CHAR,
@@ -90,6 +93,7 @@ static void do_allgathers(void)
                   buffer, 8589934592, MPI_CHAR, MPI_COMM_WORLD);
     MPI_Allgather(buffer, (MPI_Count) 32, MPI_CHAR,
                   buffer, (MPI_Count) 32, MPI_CHAR, MPI_COMM_WORLD);
+#endif
 }
 
 static void check_eq(MPI_Count a, MPI_Count b, int line)
@@ -114,10 +118,12 @@ static void do_get_elements(void)
 
     printf(">> The following functions call MPI_Get_elements_x\n");
     MPI_Count count_c;
+#if FROOZLE_HAVE_C11_GENERIC
     MPI_Get_elements(MPI_STATUS_IGNORE, MPI_CHAR, &count_c);
     CHECK_EQ(count_c, (MPI_Count) FROOZLE_TEST_SMALL_COUNT);
     MPI_Get_elements(MPI_STATUS_IGNORE, MPI_INT, &count_c);
     CHECK_EQ(count_c, FROOZLE_TEST_GIANT_COUNT_C);
+#endif
 
     MPI_Get_elements_x(MPI_STATUS_IGNORE, MPI_CHAR, &count_c);
     CHECK_EQ(count_c, (MPI_Count) FROOZLE_TEST_SMALL_COUNT);


### PR DESCRIPTION
Update example_c.c to effectively disable calling MPI_Count-enabled
MPI bindings if we do not have C11 _Generic.

Fixes #4.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>