### PR TITLE
Convert "_y" --> "_l"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,19 @@ module).
 
 # Rationale
 
-## The `_y` suffix
+## The `_l` suffix
 
-The `MPI_Count`-variant symbols in C and Fortran have a suffix of `_y`
--- not `_x`, as has been long-discussed in the Forum.  We chose `_y`
-for the following reasons:
+The `MPI_Count`-variant symbols in C and Fortran have a suffix of `_l`
+(lower case "L") -- not `_x`, as has been long-discussed in the Forum.
+We chose `_l` for the following reasons:
 
 1. It's just as short as `_x`.
+1. `_l` stands for "Large".
 1. MPI-3.0 added several `_x` functions (e.g.,
    MPI_GET_ELEMENTS_COUNT_X).
    1. We wanted to make a clean separation between the MPI-3 functions
       (i.e,. the `_x` functions) and the new symbols added in MPI-4
-      (i.e., the `_y` functions).
+      (i.e., the `_l` functions).
    1. There is actually a problem with the Fortran `mpi` and `mpi_f08`
       modules such that we *couldn't* have the underlying subroutine
       names be `_x` because they would conflict with the

--- a/c/allgather_count.c
+++ b/c/allgather_count.c
@@ -9,7 +9,7 @@
 #include "mpi.h"
 
 
-int MPI_Allgather_y(const void *sendbuf, MPI_Count sendcount,
+int MPI_Allgather_l(const void *sendbuf, MPI_Count sendcount,
                     MPI_Datatype sendtype,
                     void *recvbuf, MPI_Count recvcount,
                     MPI_Datatype recvtype, MPI_Comm comm)

--- a/c/get_elements_count.c
+++ b/c/get_elements_count.c
@@ -10,7 +10,7 @@
 #include "globals.h"
 
 
-int MPI_Get_elements_y(const MPI_Status *status,
+int MPI_Get_elements_l(const MPI_Status *status,
                        MPI_Datatype datatype, MPI_Count *count)
 {
     printf("This is C %s\n", __func__);

--- a/c/recv_count.c
+++ b/c/recv_count.c
@@ -9,7 +9,7 @@
 #include "mpi.h"
 
 
-int MPI_Recv_y(void *buf, MPI_Count count,
+int MPI_Recv_l(void *buf, MPI_Count count,
                MPI_Datatype datatype,
                int source, int tag, MPI_Comm comm,
                MPI_Status *status)

--- a/c/send_count.c
+++ b/c/send_count.c
@@ -9,7 +9,7 @@
 #include "mpi.h"
 
 
-int MPI_Send_y(const void *buf, MPI_Count count,
+int MPI_Send_l(const void *buf, MPI_Count count,
                MPI_Datatype datatype,
                int dest, int tag, MPI_Comm comm)
 {

--- a/examples/example_c.c
+++ b/examples/example_c.c
@@ -34,7 +34,7 @@ static void do_sends(void)
     MPI_Send(buffer, smallI, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 
 #if FROOZLE_HAVE_C11_GENERIC
-    printf(">> The following functions should call MPI_Send_y\n");
+    printf(">> The following functions should call MPI_Send_l\n");
     MPI_Count bigI = 8589934592;
     MPI_Send(buffer, bigI, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 
@@ -58,7 +58,7 @@ static void do_recvs(void)
              MPI_STATUS_IGNORE);
 
 #if FROOZLE_HAVE_C11_GENERIC
-    printf(">> The following functions should call MPI_Recv_y\n");
+    printf(">> The following functions should call MPI_Recv_l\n");
     MPI_Count bigI = 8589934592;
     MPI_Recv(buffer, bigI, MPI_CHAR, 0, 0, MPI_COMM_WORLD,
              MPI_STATUS_IGNORE);
@@ -85,7 +85,7 @@ static void do_allgathers(void)
                   buffer, smallI, MPI_CHAR, MPI_COMM_WORLD);
 
 #if FROOZLE_HAVE_C11_GENERIC
-    printf(">> The following functions should call MPI_Allgather_y\n");
+    printf(">> The following functions should call MPI_Allgather_l\n");
     MPI_Count bigI = 8589934592;
     MPI_Allgather(buffer, bigI, MPI_CHAR,
                   buffer, bigI, MPI_CHAR, MPI_COMM_WORLD);
@@ -116,15 +116,16 @@ static void do_get_elements(void)
     MPI_Get_elements(MPI_STATUS_IGNORE, MPI_INT, &count_i);
     CHECK_EQ(count_i, MPI_UNDEFINED);
 
-    printf(">> The following functions call MPI_Get_elements_x\n");
     MPI_Count count_c;
 #if FROOZLE_HAVE_C11_GENERIC
+    printf(">> The following functions call MPI_Get_elements_l\n");
     MPI_Get_elements(MPI_STATUS_IGNORE, MPI_CHAR, &count_c);
     CHECK_EQ(count_c, (MPI_Count) FROOZLE_TEST_SMALL_COUNT);
     MPI_Get_elements(MPI_STATUS_IGNORE, MPI_INT, &count_c);
     CHECK_EQ(count_c, FROOZLE_TEST_GIANT_COUNT_C);
 #endif
 
+    printf(">> The following functions call MPI_Get_elements_x\n");
     MPI_Get_elements_x(MPI_STATUS_IGNORE, MPI_CHAR, &count_c);
     CHECK_EQ(count_c, (MPI_Count) FROOZLE_TEST_SMALL_COUNT);
     MPI_Get_elements_x(MPI_STATUS_IGNORE, MPI_INT, &count_c);

--- a/examples/example_usempi.F90
+++ b/examples/example_usempi.F90
@@ -19,7 +19,7 @@ subroutine do_sends()
   call MPI_Send(buffer, 32, MPI_CHARACTER, 0, 0, MPI_COMM_WORLD, ierr)
   call MPI_Send(buffer, i, MPI_CHARACTER, 0, 0, MPI_COMM_WORLD, ierr)
 
-  write(*,*) '>> The following functions should call MPI_Send_y'
+  write(*,*) '>> The following functions should call MPI_Send_l'
   call MPI_Send(buffer, bigI, MPI_CHARACTER, 0, 0, MPI_COMM_WORLD, ierr)
   call MPI_Send(buffer, 858993459_MPI_COUNT_KIND, MPI_CHARACTER, &
        0, 0, MPI_COMM_WORLD, ierr)
@@ -41,7 +41,7 @@ subroutine do_recvs()
   call MPI_Recv(buffer, i, MPI_CHARACTER, 0, 0, MPI_COMM_WORLD, &
        MPI_STATUS_IGNORE, ierr)
 
-  write(*,*) '>> The following functions should call MPI_Recv_y'
+  write(*,*) '>> The following functions should call MPI_Recv_l'
   call MPI_Recv(buffer, bigI, MPI_CHARACTER, 0, 0, MPI_COMM_WORLD, &
        MPI_STATUS_IGNORE, ierr)
   call MPI_Recv(buffer, 8589934592_MPI_COUNT_KIND, MPI_CHARACTER, &
@@ -65,7 +65,7 @@ subroutine do_allgathers()
   call MPI_Allgather(buffer, i, MPI_CHARACTER, &
        buffer, i, MPI_CHARACTER, &
        MPI_COMM_WORLD, ierr)
-  write(*,*) '>> The following functions should call MPI_Allgather_y'
+  write(*,*) '>> The following functions should call MPI_Allgather_l'
   call MPI_Allgather(buffer, bigI, MPI_CHARACTER, &
        buffer, bigI, MPI_CHARACTER, &
        MPI_COMM_WORLD, ierr)
@@ -111,7 +111,7 @@ subroutine do_get_elements()
   call MPI_Get_elements(MPI_STATUS_IGNORE, MPI_INTEGER, i, ierr)
   call check_eq_i(i, MPI_UNDEFINED)
 
-  write(*,*) ">> The following functions call MPI_Get_elements_y"
+  write(*,*) ">> The following functions call MPI_Get_elements_l"
   call MPI_Get_elements(MPI_STATUS_IGNORE, MPI_CHARACTER, c, ierr)
   call check_eq_c(c, INT(FROOZLE_TEST_SMALL_COUNT, KIND=MPI_COUNT_KIND))
   call MPI_Get_elements(MPI_STATUS_IGNORE, MPI_INTEGER, c, ierr)

--- a/examples/example_usempif08.F90
+++ b/examples/example_usempif08.F90
@@ -19,7 +19,7 @@ subroutine do_sends()
   call MPI_Send(buffer, 32, MPI_CHARACTER, 0, 0, MPI_COMM_WORLD, ierr)
   call MPI_Send(buffer, i, MPI_CHARACTER, 0, 0, MPI_COMM_WORLD, ierr)
 
-  write(*,*) '>> The following functions should call MPI_Send_y'
+  write(*,*) '>> The following functions should call MPI_Send_l'
   call MPI_Send(buffer, bigI, MPI_CHARACTER, 0, 0, MPI_COMM_WORLD, ierr)
   call MPI_Send(buffer, 858993459_MPI_COUNT_KIND, MPI_CHARACTER, &
        0, 0, MPI_COMM_WORLD, ierr)
@@ -41,7 +41,7 @@ subroutine do_recvs()
   call MPI_Recv(buffer, i, MPI_CHARACTER, 0, 0, MPI_COMM_WORLD, &
        MPI_STATUS_IGNORE, ierr)
 
-  write(*,*) '>> The following functions should call MPI_Recv_y'
+  write(*,*) '>> The following functions should call MPI_Recv_l'
   call MPI_Recv(buffer, bigI, MPI_CHARACTER, 0, 0, MPI_COMM_WORLD, &
        MPI_STATUS_IGNORE, ierr)
   call MPI_Recv(buffer, 8589934592_MPI_COUNT_KIND, MPI_CHARACTER, &
@@ -65,7 +65,7 @@ subroutine do_allgathers()
   call MPI_Allgather(buffer, i, MPI_CHARACTER, &
        buffer, i, MPI_CHARACTER, &
        MPI_COMM_WORLD, ierr)
-  write(*,*) '>> The following functions should call MPI_Allgather_y'
+  write(*,*) '>> The following functions should call MPI_Allgather_l'
   call MPI_Allgather(buffer, bigI, MPI_CHARACTER, &
        buffer, bigI, MPI_CHARACTER, &
        MPI_COMM_WORLD, ierr)
@@ -111,7 +111,7 @@ subroutine do_get_elements()
   call MPI_Get_elements(MPI_STATUS_IGNORE, MPI_INTEGER, i, ierr)
   call check_eq_i(i, MPI_UNDEFINED)
 
-  write(*,*) ">> The following functions call MPI_Get_elements_y"
+  write(*,*) ">> The following functions call MPI_Get_elements_l"
   call MPI_Get_elements(MPI_STATUS_IGNORE, MPI_CHARACTER, c, ierr)
   call check_eq_c(c, INT(FROOZLE_TEST_SMALL_COUNT, KIND=MPI_COUNT_KIND))
   call MPI_Get_elements(MPI_STATUS_IGNORE, MPI_INTEGER, c, ierr)

--- a/fortran-usempi/allgather_count_usempi.F90
+++ b/fortran-usempi/allgather_count_usempi.F90
@@ -5,7 +5,7 @@
 
 #include "froozle_config_fortran.h"
 
-subroutine MPI_Allgather_y(sendbuf, sendcount, sendtype, recvbuf, recvcount, &
+subroutine MPI_Allgather_l(sendbuf, sendcount, sendtype, recvbuf, recvcount, &
      recvtype, comm, ierror)
   include 'mpif-constants.h'
   FROOZLE_FORTRAN_IGNORE_TKR_PREDECL sendbuf
@@ -19,5 +19,5 @@ subroutine MPI_Allgather_y(sendbuf, sendcount, sendtype, recvbuf, recvcount, &
   integer, intent(in) :: comm
   integer, intent(out) :: ierror
 
-  write(*,*) 'This is mpi module MPI_Allgather_y'
-end subroutine MPI_Allgather_y
+  write(*,*) 'This is mpi module MPI_Allgather_l'
+end subroutine MPI_Allgather_l

--- a/fortran-usempi/get_elements_count_usempi.F90
+++ b/fortran-usempi/get_elements_count_usempi.F90
@@ -3,7 +3,7 @@
 
 #include "froozle_config_fortran.h"
 
-subroutine MPI_Get_elements_y(status, datatype, count, ierr)
+subroutine MPI_Get_elements_l(status, datatype, count, ierr)
   implicit none
 
   include 'mpif-constants.h'
@@ -15,9 +15,9 @@ subroutine MPI_Get_elements_y(status, datatype, count, ierr)
 
   integer :: dummy
 
-  write(*,*) 'This is mpi module MPI_Get_elements_y'
+  write(*,*) 'This is mpi module MPI_Get_elements_l'
 
   ! Do the back-end work in C -- the strong type safety in Fortran is
   ! too restrictive.
   call froozle_get_elements_f(datatype, dummy, count)
-end subroutine MPI_Get_elements_y
+end subroutine MPI_Get_elements_l

--- a/fortran-usempi/mpi-module.F90
+++ b/fortran-usempi/mpi-module.F90
@@ -55,7 +55,7 @@ module mpi
        integer, intent(out) :: ierror
      end subroutine MPI_Allgather
 
-     subroutine MPI_Allgather_y(sendbuf, sendcount, sendtype, recvbuf, recvcount, &
+     subroutine MPI_Allgather_l(sendbuf, sendcount, sendtype, recvbuf, recvcount, &
           recvtype, comm, ierror)
        include 'mpif-constants.h'
        FROOZLE_FORTRAN_IGNORE_TKR_PREDECL sendbuf
@@ -68,7 +68,7 @@ module mpi
        integer, intent(in) :: recvtype
        integer, intent(in) :: comm
        integer, intent(out) :: ierror
-     end subroutine MPI_Allgather_y
+     end subroutine MPI_Allgather_l
   end interface MPI_Allgather
 
   interface MPI_Get_elements
@@ -82,13 +82,13 @@ module mpi
      ! The _x version of this interface effectively already exists (as
      ! a different interface), so we have to give the underlying
      ! function a different name.
-     subroutine MPI_Get_elements_y(status, datatype, count, ierr)
+     subroutine MPI_Get_elements_l(status, datatype, count, ierr)
        include 'mpif-constants.h'
        integer, dimension(MPI_STATUS_SIZE), intent(in) :: status
        integer, intent(in) :: datatype
        integer(kind=MPI_COUNT_KIND), intent(out) :: count
        integer, intent(out) :: ierr
-     end subroutine MPI_Get_elements_y
+     end subroutine MPI_Get_elements_l
   end interface MPI_Get_elements
 
   interface MPI_Get_elements_x
@@ -114,7 +114,7 @@ module mpi
        integer, intent(out) :: ierror
      end subroutine MPI_Send
 
-     subroutine MPI_Send_y(buf, count, datatype, dest, tag, &
+     subroutine MPI_Send_l(buf, count, datatype, dest, tag, &
           comm, ierror)
        include 'mpif-constants.h'
        FROOZLE_FORTRAN_IGNORE_TKR_PREDECL buf
@@ -125,7 +125,7 @@ module mpi
        integer, intent(in) :: tag
        integer, intent(in) :: comm
        integer, intent(out) :: ierror
-     end subroutine MPI_Send_y
+     end subroutine MPI_Send_l
   end interface MPI_Send
 
   interface MPI_Recv
@@ -143,7 +143,7 @@ module mpi
        integer, intent(out) :: ierror
      end subroutine MPI_Recv
 
-       subroutine MPI_Recv_y(buf, count, datatype, source, tag, &
+       subroutine MPI_Recv_l(buf, count, datatype, source, tag, &
           comm, status, ierror)
        include 'mpif-constants.h'
        FROOZLE_FORTRAN_IGNORE_TKR_PREDECL buf
@@ -155,7 +155,7 @@ module mpi
        integer, intent(in) :: comm
        integer, dimension(MPI_STATUS_SIZE), intent(out) :: status
        integer, intent(out) :: ierror
-     end subroutine MPI_Recv_y
+     end subroutine MPI_Recv_l
   end interface MPI_Recv
 
   ! Back-end C function to do the work for MPI_Get_elements[_x]

--- a/fortran-usempi/recv_count_usempi.F90
+++ b/fortran-usempi/recv_count_usempi.F90
@@ -5,7 +5,7 @@
 
 #include "froozle_config_fortran.h"
 
-subroutine MPI_Recv_y(buf, count, datatype, source, tag, &
+subroutine MPI_Recv_l(buf, count, datatype, source, tag, &
      comm, status, ierror)
   include 'mpif-constants.h'
   FROOZLE_FORTRAN_IGNORE_TKR_PREDECL buf
@@ -18,5 +18,5 @@ subroutine MPI_Recv_y(buf, count, datatype, source, tag, &
   integer, dimension(MPI_STATUS_SIZE), intent(out) :: status
   integer, intent(out) :: ierror
 
-  write(*,*) 'This is mpi module MPI_Recv_y'
-end subroutine MPI_Recv_y
+  write(*,*) 'This is mpi module MPI_Recv_l'
+end subroutine MPI_Recv_l

--- a/fortran-usempi/send_count_usempi.F90
+++ b/fortran-usempi/send_count_usempi.F90
@@ -5,7 +5,7 @@
 
 #include "froozle_config_fortran.h"
 
-subroutine MPI_Send_y(buf, count, datatype, dest, tag, &
+subroutine MPI_Send_l(buf, count, datatype, dest, tag, &
      comm, ierror)
   include 'mpif-constants.h'
   FROOZLE_FORTRAN_IGNORE_TKR_PREDECL buf
@@ -17,5 +17,5 @@ subroutine MPI_Send_y(buf, count, datatype, dest, tag, &
   integer, intent(in) :: comm
   integer, intent(out) :: ierror
 
-  write(*,*) 'This is mpi module MPI_Send_y'
-end subroutine MPI_Send_y
+  write(*,*) 'This is mpi module MPI_Send_l'
+end subroutine MPI_Send_l

--- a/fortran-usempif08/allgather_count_usempif08.F90
+++ b/fortran-usempif08/allgather_count_usempif08.F90
@@ -5,7 +5,7 @@
 
 #include "froozle_config_fortran.h"
 
-subroutine MPI_Allgather_y_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount,recvtype, &
+subroutine MPI_Allgather_l_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount,recvtype, &
      comm,ierror)
   use :: mpi_f08_types
   implicit none
@@ -21,5 +21,5 @@ subroutine MPI_Allgather_y_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount,recv
   TYPE(MPI_Comm), INTENT(IN) :: comm
   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-  write(*,*) 'This is mpi_f08 module MPI_Allgather_y_f08'
-end subroutine MPI_Allgather_y_f08
+  write(*,*) 'This is mpi_f08 module MPI_Allgather_l_f08'
+end subroutine MPI_Allgather_l_f08

--- a/fortran-usempif08/get_elements_count_usempif08.F90
+++ b/fortran-usempif08/get_elements_count_usempif08.F90
@@ -5,7 +5,7 @@
 
 #include "froozle_config_fortran.h"
 
-subroutine MPI_Get_elements_y_f08(status, datatype, count, ierr)
+subroutine MPI_Get_elements_l_f08(status, datatype, count, ierr)
   use :: mpi_f08_types
   implicit none
 
@@ -16,9 +16,9 @@ subroutine MPI_Get_elements_y_f08(status, datatype, count, ierr)
 
   integer :: dummy
 
-  write(*,*) 'This is mpi_f08 module MPI_Get_elements_y_f08'
+  write(*,*) 'This is mpi_f08 module MPI_Get_elements_l_f08'
 
   ! Do the back-end work in C -- the strong type safety in Fortran is
   ! too restrictive.
   call froozle_get_elements_f(datatype, dummy, count)
-end subroutine MPI_Get_elements_y_f08
+end subroutine MPI_Get_elements_l_f08

--- a/fortran-usempif08/mpi-f08-module.F90
+++ b/fortran-usempif08/mpi-f08-module.F90
@@ -52,14 +52,14 @@ module mpi_f08
        integer, optional, intent(out) :: ierr
      end subroutine MPI_Get_elements_f08
 
-     subroutine MPI_Get_elements_y_f08(status, datatype, count, ierr)
+     subroutine MPI_Get_elements_l_f08(status, datatype, count, ierr)
        use :: mpi_f08_types
        implicit none
        type(MPI_Status), intent(in) :: status
        type(MPI_Datatype), intent(in) :: datatype
        integer(kind=MPI_COUNT_KIND), intent(out) :: count
        integer, optional, intent(out) :: ierr
-     end subroutine MPI_Get_elements_y_f08
+     end subroutine MPI_Get_elements_l_f08
   end interface MPI_Get_elements
 
   interface MPI_Get_elements_x
@@ -91,7 +91,7 @@ module mpi_f08
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
      end subroutine MPI_Allgather_f08
 
-     subroutine MPI_Allgather_y_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount,recvtype, &
+     subroutine MPI_Allgather_l_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount,recvtype, &
           comm,ierror)
        use :: mpi_f08_types
        implicit none
@@ -106,7 +106,7 @@ module mpi_f08
        TYPE(MPI_Datatype), INTENT(IN) :: sendtype, recvtype
        TYPE(MPI_Comm), INTENT(IN) :: comm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
-     end subroutine MPI_Allgather_y_f08
+     end subroutine MPI_Allgather_l_f08
   end interface  MPI_Allgather
 
   interface  MPI_Send
@@ -125,7 +125,7 @@ module mpi_f08
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
      end subroutine MPI_Send_f08
 
-     subroutine MPI_Send_y_f08(buf,count,datatype,dest,tag,comm,ierror)
+     subroutine MPI_Send_l_f08(buf,count,datatype,dest,tag,comm,ierror)
        use :: mpi_f08_types
        implicit none
        !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
@@ -139,7 +139,7 @@ module mpi_f08
        TYPE(MPI_Datatype), INTENT(IN) :: datatype
        TYPE(MPI_Comm), INTENT(IN) :: comm
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
-     end subroutine MPI_Send_y_f08
+     end subroutine MPI_Send_l_f08
   end interface  MPI_Send
 
   interface  MPI_Recv
@@ -159,7 +159,7 @@ module mpi_f08
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
      end subroutine MPI_Recv_f08
 
-     subroutine MPI_Recv_y_f08(buf,count,datatype,source,tag,comm,status,ierror)
+     subroutine MPI_Recv_l_f08(buf,count,datatype,source,tag,comm,status,ierror)
        use :: mpi_f08_types
        implicit none
        !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
@@ -174,7 +174,7 @@ module mpi_f08
        TYPE(MPI_Comm), INTENT(IN) :: comm
        TYPE(MPI_Status) :: status
        INTEGER, OPTIONAL, INTENT(OUT) :: ierror
-     end subroutine MPI_Recv_y_f08
+     end subroutine MPI_Recv_l_f08
   end interface  MPI_Recv
 
   ! Back-end C function to do the work for MPI_Get_elements[_x]

--- a/fortran-usempif08/recv_count_usempif08.F90
+++ b/fortran-usempif08/recv_count_usempif08.F90
@@ -5,7 +5,7 @@
 
 #include "froozle_config_fortran.h"
 
-subroutine MPI_Recv_y_f08(buf,count,datatype,source,tag,comm,status,ierror)
+subroutine MPI_Recv_l_f08(buf,count,datatype,source,tag,comm,status,ierror)
   use :: mpi_f08_types
   implicit none
   !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
@@ -21,5 +21,5 @@ subroutine MPI_Recv_y_f08(buf,count,datatype,source,tag,comm,status,ierror)
   TYPE(MPI_Status) :: status
   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-  write(*,*) 'This is mpi_f08 module MPI_Recv_y_f08'
-end subroutine MPI_Recv_y_f08
+  write(*,*) 'This is mpi_f08 module MPI_Recv_l_f08'
+end subroutine MPI_Recv_l_f08

--- a/fortran-usempif08/send_count_usempif08.F90
+++ b/fortran-usempif08/send_count_usempif08.F90
@@ -5,7 +5,7 @@
 
 #include "froozle_config_fortran.h"
 
-subroutine MPI_Send_y_f08(buf,count,datatype,dest,tag,comm,ierror)
+subroutine MPI_Send_l_f08(buf,count,datatype,dest,tag,comm,ierror)
   use :: mpi_f08_types
   implicit none
   !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
@@ -20,5 +20,5 @@ subroutine MPI_Send_y_f08(buf,count,datatype,dest,tag,comm,ierror)
   TYPE(MPI_Comm), INTENT(IN) :: comm
   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 
-  write(*,*) 'This is mpi_f08 module MPI_Send_y_f08'
-end subroutine MPI_Send_y_f08
+  write(*,*) 'This is mpi_f08 module MPI_Send_l_f08'
+end subroutine MPI_Send_l_f08

--- a/include/mpi.h
+++ b/include/mpi.h
@@ -47,42 +47,43 @@ int MPI_Get_elements_x(const MPI_Status *status,
     _Generic(count,                                         \
              default: MPI_Send,                             \
              int: MPI_Send,                                 \
-             MPI_Count: MPI_Send_y                          \
+             MPI_Count: MPI_Send_l                          \
              )(buf, count, dt, rank, tag, comm)
 
 #define MPI_Recv(buf, count, dt, rank, tag, comm, status)   \
     _Generic(count,                                         \
              default: MPI_Recv,                             \
              int: MPI_Recv,                                 \
-             MPI_Count: MPI_Recv_y                          \
+             MPI_Count: MPI_Recv_l                          \
              )(buf, count, dt, rank, tag, comm, status)
 
 #define MPI_Allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm) \
     _Generic(sendcount,                                                 \
              default: MPI_Allgather,                                    \
              int: MPI_Allgather,                                        \
-             MPI_Count: MPI_Allgather_y                                 \
+             MPI_Count: MPI_Allgather_l                                 \
              )(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
+
 
 #define MPI_Get_elements(status, datatype, count)         \
     _Generic(count,                                       \
              default: MPI_Get_elements,                   \
              int *: MPI_Get_elements,                     \
-             MPI_Count *: MPI_Get_elements_y              \
+             MPI_Count *: MPI_Get_elements_l              \
              )(status, datatype, count)
 
-int MPI_Send_y(const void *buf, MPI_Count count,
+int MPI_Send_l(const void *buf, MPI_Count count,
                MPI_Datatype datatype,
                int dest, int tag, MPI_Comm comm);
-int MPI_Recv_y(void *buf, MPI_Count count,
+int MPI_Recv_l(void *buf, MPI_Count count,
                MPI_Datatype datatype,
                int source, int tag, MPI_Comm comm,
                MPI_Status *status);
-int MPI_Allgather_y(const void *sendbuf, MPI_Count sendcount,
+int MPI_Allgather_l(const void *sendbuf, MPI_Count sendcount,
                     MPI_Datatype sendtype,
                     void *recvbuf, MPI_Count recvcount,
                     MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Get_elements_y(const MPI_Status *status,
+int MPI_Get_elements_l(const MPI_Status *status,
                        MPI_Datatype datatype,
                        MPI_Count *count);
 


### PR DESCRIPTION
Convert all suffixes from "_y" to "_l", where "l" stands for "large".

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>