### PR TITLE
Fix warnings in "make distcheck"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,7 @@ AC_DEFINE_UNQUOTED([FROOZLE_TEST_GIANT_COUNT_F],
 
 dnl ----------------------------------------------------------------
 
-AC_CONFIG_HEADER([include/mpi-config.h])
+AC_CONFIG_HEADER([include/mpi.h])
 AC_CONFIG_HEADER([include/froozle_config_fortran.h])
 
 AC_OUTPUT([

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -2,7 +2,6 @@
 
 include_HEADERS = \
         mpi.h \
-        mpi-config.h \
         mpif.h \
         mpif-constants.h \
         mpif-handles.h \

--- a/include/mpi.h.in
+++ b/include/mpi.h.in
@@ -7,13 +7,12 @@
 
 /***************************************************************/
 
-#include "mpi-config.h"
-
-/***************************************************************/
-
 #ifndef FROOZLE_BUILDING
 #define FROOZLE_BUILDING 0
 #endif
+
+// Substituted in by configure script
+#define FROOZLE_HAVE_C11_GENERIC @FROOZLE_HAVE_C11_GENERIC@
 
 /***************************************************************/
 
@@ -105,18 +104,12 @@ int MPI_Get_elements_x(const MPI_Status *status,
                        MPI_Count *count);
 
 
-// This comes from mpi-config.h
-#define FROOZLE_WANT_C11_GENERIC FROOZLE_HAVE_C11_GENERIC
-
-// We don't want _Generic if we're building Froozle itself
-#if FROOZLE_BUILDING
-#undef FROOZLE_WANT_C11_GENERIC
+// We don't want _Generic if we're building Froozle itself, or if we're in C++
+#if FROOZLE_BUILDING || defined(c_plusplus) || defined(__cplusplus)
 #define FROOZLE_WANT_C11_GENERIC 0
-#endif
-
-// We also don't want _Generic if we're in C++
-#if defined(c_plusplus) || defined(__cplusplus)
-#undef FROOZLE_WANT_C11_GENERIC
+#elif FROOZLE_HAVE_C11_GENERIC
+#define FROOZLE_WANT_C11_GENERIC 1
+#else
 #define FROOZLE_WANT_C11_GENERIC 0
 #endif
 


### PR DESCRIPTION
Fix warnings when you configured with --disable-c11-generic and then
ran "make distcheck" (just have all config in mpi.h. directly --
especially now that there's no C++, there's no need for a separate
mpi-config.h).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Fixes #17