### PR TITLE
Add C11 citation

### DIFF
--- a/examples/example_c.c
+++ b/examples/example_c.c
@@ -58,7 +58,7 @@ static void do_sends(void)
     // therefore the #define does not actually pre-processor replace the
     // "MPI_Send" below with the C11 _Generic expression.  Hence,
     // "MPI_Send" below returns a pointer to the int flavor of the MPI_Send
-    // function.
+    // function.  See C11 6.10.3, paragraph 10 for more explanation.
 
     // Now that we have function pointers, the normal C promotion
     // rules apply to the count parameter.


### PR DESCRIPTION
Jim Dinan provided a helpful C11 citation reference as to exactly why
"MPI_Send" (with no ()) will give us the function pointer, rather than
trigger the preprocessor macro.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>